### PR TITLE
[Snake] Remove tuples and use Position struct

### DIFF
--- a/Snake/Snake.xcodeproj/project.pbxproj
+++ b/Snake/Snake.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BF06E102245152850096FA5D /* Structs.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF06E101245152850096FA5D /* Structs.swift */; };
 		BF88DFC524476374005A362C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF88DFC424476374005A362C /* AppDelegate.swift */; };
 		BF88DFC724476374005A362C /* GameScene.sks in Resources */ = {isa = PBXBuildFile; fileRef = BF88DFC624476374005A362C /* GameScene.sks */; };
 		BF88DFCB24476374005A362C /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF88DFCA24476374005A362C /* GameScene.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BF06E101245152850096FA5D /* Structs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Structs.swift; sourceTree = "<group>"; };
 		BF88DFC124476374005A362C /* Snake.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Snake.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF88DFC424476374005A362C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BF88DFC624476374005A362C /* GameScene.sks */ = {isa = PBXFileReference; lastKnownFileType = file.sks; path = GameScene.sks; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 				BF88DFC424476374005A362C /* AppDelegate.swift */,
 				BF88DFC624476374005A362C /* GameScene.sks */,
 				BF88DFCA24476374005A362C /* GameScene.swift */,
+				BF06E101245152850096FA5D /* Structs.swift */,
 				BF88DFDC24476595005A362C /* GameManager.swift */,
 				BF88DFCC24476374005A362C /* GameViewController.swift */,
 				BF88DFCE24476374005A362C /* Main.storyboard */,
@@ -147,6 +150,7 @@
 			files = (
 				BF88DFCB24476374005A362C /* GameScene.swift in Sources */,
 				BF88DFDD24476595005A362C /* GameManager.swift in Sources */,
+				BF06E102245152850096FA5D /* Structs.swift in Sources */,
 				BF88DFCD24476374005A362C /* GameViewController.swift in Sources */,
 				BF88DFC524476374005A362C /* AppDelegate.swift in Sources */,
 			);

--- a/Snake/Snake/GameManager.swift
+++ b/Snake/Snake/GameManager.swift
@@ -29,21 +29,25 @@ class GameManager {
     }
     
     func initGame() {
-        scene.playerPositions.append((10, 10))
-        scene.playerPositions.append((10, 11))
-        scene.playerPositions.append((10, 12))
+        scene.playerPositions.append(Position(x: 10, y: 10))
+        scene.playerPositions.append(Position(x: 11, y: 10))
+        scene.playerPositions.append(Position(x: 12, y: 10))
         renderChange()
         generateNewPoint()
     }
     
     private func generateNewPoint() {
-        var randomX = CGFloat(arc4random_uniform(19))
-        var randomY = CGFloat(arc4random_uniform(39))
-        while contains(a: scene.playerPositions, v: (Int(randomX), Int(randomY))) {  // TODO: Is this a bug? Should the order be flipped? I think sometimes the apple is showing up underneath the snake's tail.
-            randomX = CGFloat(arc4random_uniform(19))
-            randomY = CGFloat(arc4random_uniform(39))
+        var position = generateRandomPosition()
+        while scene.playerPositions.contains(position) {
+            position = generateRandomPosition()
         }
-        scene.scorePos = CGPoint(x: randomX, y: randomY)  // TODO: Don't use CGPoint with CGFloat values; use (x: Int, y: Int)
+        scene.scorePos = position
+    }
+    
+    func generateRandomPosition() -> Position {
+        let randomX = Int(arc4random_uniform(19))
+        let randomY = Int(arc4random_uniform(39))
+        return Position(x: randomX, y: randomY)
     }
     
     func update(time: Double) {  // In GameScene, we call this with a TimeInterval
@@ -61,13 +65,14 @@ class GameManager {
     }
     
     func renderChange() {
-        for (node, x, y) in scene.gameArray {
-            if contains(a: scene.playerPositions, v: (x, y)) {
+        for cell in scene.gameArray {
+            let node = cell.node
+            if contains(a: scene.playerPositions, v: cell.position) {
                 node.fillColor = SKColor.cyan
             } else {
                 node.fillColor = SKColor.clear
                 if scene.scorePos != nil {
-                    if Int((scene.scorePos?.x)!) == y && Int((scene.scorePos?.y)!) == x { // TODO: This is dumb that we're comparing x to y
+                    if scene.scorePos! == cell.position {
                         node.fillColor = SKColor.red
                     }
                 }
@@ -75,14 +80,8 @@ class GameManager {
         }
     }
     
-    func contains(a: [(Int, Int)], v: (Int, Int)) -> Bool {  // TODO: Use native Array.contains method
-        let (c1, c2) = v
-        for (v1, v2) in a {
-            if v1 == c1 && v2 == c2 {
-                return true
-            }
-        }
-        return false
+    func contains(a: [Position], v: Position) -> Bool {
+        return a.contains(v)
     }
     
     func updatePlayerPosition() {
@@ -115,19 +114,19 @@ class GameManager {
                 scene.playerPositions[start] = scene.playerPositions[start - 1]
                 start -= 1
             }
-            scene.playerPositions[0] = (scene.playerPositions[0].0 + yChange, scene.playerPositions[0].1 + xChange)
+            scene.playerPositions[0] = Position(x: scene.playerPositions[0].x + xChange, y: scene.playerPositions[0].y + yChange)
         }
         if scene.playerPositions.count > 0 {
-            let x = scene.playerPositions[0].1
-            let y = scene.playerPositions[0].0
+            let x = scene.playerPositions[0].x
+            let y = scene.playerPositions[0].y
             if y > 39 {
-                scene.playerPositions[0].0 = 0
+                scene.playerPositions[0].y = 0
             } else if y < 0 {
-                scene.playerPositions[0].0 = 39
+                scene.playerPositions[0].y = 39
             } else if x > 19 {
-                scene.playerPositions[0].1 = 0
+                scene.playerPositions[0].x = 0
             } else if x < 0 {
-                scene.playerPositions[0].1 = 19
+                scene.playerPositions[0].x = 19
             }
         }
         renderChange()
@@ -135,9 +134,7 @@ class GameManager {
     
     private func checkForScore() {
         if scene.scorePos != nil {  // TODO: Change to an if let statement
-            let x = scene.playerPositions[0].0
-            let y = scene.playerPositions[0].1
-            if Int((scene.scorePos?.x)!) == y && Int((scene.scorePos?.y)!) == x {
+            if scene.scorePos! == scene.playerPositions[0] {
                 currentScore += 1
                 scene.currentScore.text = "Score: \(currentScore)"
                 generateNewPoint()

--- a/Snake/Snake/GameScene.swift
+++ b/Snake/Snake/GameScene.swift
@@ -10,16 +10,16 @@ import SpriteKit
 import GameplayKit
 
 class GameScene: SKScene {
-
+    
     var gameLogo: SKLabelNode!
     var bestScore: SKLabelNode!
     var playButton: SKShapeNode!
     var game: GameManager!
     var currentScore: SKLabelNode!
-    var playerPositions: [(Int, Int)] = []  // TODO: Label the x and y
+    var playerPositions: [Position] = []
     var gameBG: SKShapeNode!
-    var gameArray: [(node: SKShapeNode, x: Int, y: Int)] = []
-    var scorePos: CGPoint?  // TODO: Make this a tuple too?
+    var gameArray: [Cell] = []
+    var scorePos: Position?
     
     override func didMove(to view: SKView) {
         initializeMenu()
@@ -154,13 +154,14 @@ class GameScene: SKScene {
         let cellHeight: CGFloat = CGFloat(height) / 40
         var x = CGFloat(width / -2) + (cellWidth / 2)
         var y = CGFloat(height / 2) - (cellHeight / 2)
-        for i in 0...numRows - 1 {
-            for j in 0...numCols - 1 {
+        for j in 0...numRows - 1 {
+            for i in 0...numCols - 1 {
                 let cellNode = SKShapeNode(rectOf: CGSize(width: cellWidth, height: cellHeight))
                 cellNode.strokeColor = SKColor.black
                 cellNode.zPosition = 2
                 cellNode.position = CGPoint(x: x, y: y)
-                gameArray.append((node: cellNode, x: i, y: j))
+                let cell = Cell(node: cellNode, position: Position(x: i, y: j))
+                gameArray.append(cell)
                 gameBG.addChild(cellNode)
                 x += cellWidth
             }

--- a/Snake/Snake/Structs.swift
+++ b/Snake/Snake/Structs.swift
@@ -1,0 +1,19 @@
+//
+//  Structs.swift
+//  Snake
+//
+//  Created by Riley John Gibbs on 4/22/20.
+//  Copyright © 2020 Riley John Gibbs. All rights reserved.
+//
+
+import SpriteKit
+
+struct Position: Equatable {
+    var x: Int
+    var y: Int
+}
+
+struct Cell {
+    let node: SKShapeNode
+    let position: Position
+}


### PR DESCRIPTION
It can easily get confusing to remember whether the first `Int` in a `(Int, Int)` tuple refers to the `x` or the `y` position. It's easier to always refer to the coordinates by `x` or `y` explicitly and not rely on the index in the tuple.

- Create `struct Position` with values `x: Int` and `y: Int`.
  - Implement [`Equatable`](https://developer.apple.com/documentation/swift/equatable) protocol so that it's not necessary to check `x` and `y` separately.
- Create `struct Cell` that also uses `Position`.
- Use `Position` for `GameScene.scorePos`.
- Refactor all instances of `playerPositions`, `scorePos`, and `gameArray` to use and expect `Position` instead of tuples.
- Simplify the `GameManager.contains` method, which we can do since `Position` implements `Equatable`.

Worth noting that this also fixes a bug where `scorePos` could show up under the snake's tail.